### PR TITLE
Provide missing Ubuntu package

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,4 @@
 #File defaults/main.yml
 ---
-ruby_builder_ruby_version: 2.1.0
+ruby_builder_ruby_version: 2.2.1
 ruby_builder_environment_path: "/usr/local/ruby/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -12,6 +12,7 @@ ruby_builder_rhel_ruby_dependencies:
   - zlib-devel
 ruby_builder_deb_ruby_dependencies:
   - git
+  - libffi-dev
   - libreadline-dev
   - libssl-dev
   - libyaml-dev


### PR DESCRIPTION
Per https://github.com/sstephenson/ruby-build/issues/690, libffi-dev is needed to cleanly compile ruby-build on Ubuntu 14.04.
